### PR TITLE
Rename project org.sugarj.editor to editor.

### DIFF
--- a/editor/.project
+++ b/editor/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.sugarj.editor</name>
+	<name>editor</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
The project `org.sugarj.editor` is referred to as `editor` in some build files, so I renamed it to make compilation work. The plugin defined by that project is still called `org.sugarj.editor`.
