### PR TITLE
Write non-LanguageLib generated files to separate directory

### DIFF
--- a/common/src/org/sugarj/common/Environment.java
+++ b/common/src/org/sugarj/common/Environment.java
@@ -36,6 +36,8 @@ public class Environment implements Serializable {
   
   private Path cacheDir = null;
   
+  private Path genDir;
+  
   private Path root = new AbsolutePath(".");
   
   private Path bin = new AbsolutePath(".");
@@ -102,6 +104,17 @@ public class Environment implements Serializable {
     this.cacheDir = cacheDir;
   }
 
+  public Path getGenDir() {
+    return genDir;
+  }
+
+  public void setGenDir(Path genDir) {
+    if (this.genDir!=null)
+      includePath.remove(this.genDir);
+    this.genDir = genDir;
+    includePath.add(genDir);
+  }
+
   public boolean isAtomicImportParsing() {
     return atomicImportParsing;
   }
@@ -140,6 +153,10 @@ public class Environment implements Serializable {
   
   public RelativePath createCachePath(String relativePath) {
     return new RelativePath(cacheDir, relativePath);
+  }
+  
+  public RelativePath createGenPath(String relativePath) {
+    return new RelativePath(genDir, relativePath);
   }
   
   public List<Renaming> getRenamings() {

--- a/compiler/org/sugarj/driver/Driver.java
+++ b/compiler/org/sugarj/driver/Driver.java
@@ -253,8 +253,7 @@ public class Driver{
       
       if (result != null
           && result.getSugaredSyntaxTree() != null
-          && result.isUpToDate(declProvider.getSourceHashCode(), driver.environment)
-          && !result.isGenerationPending())
+          && result.isUpToDate(declProvider.getSourceHashCode(), driver.environment))
         return result;
     }
     

--- a/compiler/org/sugarj/driver/ImportCommands.java
+++ b/compiler/org/sugarj/driver/ImportCommands.java
@@ -183,11 +183,11 @@ public class ImportCommands {
     if (modelPath == null)
       return null;
     if (transformationPath == null)
-      return environment.createBinPath(modelPath + ".model");
+      return environment.createGenPath(modelPath + ".model");
     
     String transformationPathString = FileCommands.dropExtension(transformationPath.getRelativePath());
     String transformedModelPath = FileCommands.dropExtension(modelPath.getRelativePath()) + "__" + transformationPathString.replace('/', '_');
-    return environment.createBinPath(transformedModelPath + ".model");
+    return environment.createGenPath(transformedModelPath + ".model");
   }
   
   /**

--- a/compiler/org/sugarj/driver/Result.java
+++ b/compiler/org/sugarj/driver/Result.java
@@ -235,6 +235,9 @@ public class Result implements IErrorLogger {
   }
 
   public boolean isUpToDateShallow(int inputHash, Environment env) throws IOException {
+     if (generationPending && env.doGenerateFiles())
+       return false;
+     
      if (hasPersistentVersionChanged())
       return false;
     

--- a/compiler/org/sugarj/driver/cli/DriverCLI.java
+++ b/compiler/org/sugarj/driver/cli/DriverCLI.java
@@ -420,8 +420,10 @@ public class DriverCLI {
     if (line.hasOption("d"))
       environment.setBin(pathArgument(line.getOptionValue("d")));
     
-    if (line.hasOption("cache"))
+    if (line.hasOption("cache")) {
       environment.setCacheDir(pathArgument(line.getOptionValue("cache")));
+      environment.setGenDir(environment.createCachePath("gen"));
+    }
   
     if (line.hasOption("gen-files"))
       environment.setGenerateFiles(true);

--- a/compiler/org/sugarj/driver/cli/Main.java
+++ b/compiler/org/sugarj/driver/cli/Main.java
@@ -71,6 +71,7 @@ public class Main {
   private static Environment getConsoleEnvironment() {
     Environment environment = new Environment(true);
     environment.setCacheDir(new RelativePath(new AbsolutePath(FileCommands.TMP_DIR), ".sugarjcache"));
+    environment.setGenDir(environment.createCachePath("gen"));
     environment.getSourcePath().add(new AbsolutePath("."));
     environment.setAtomicImportParsing(true);
     environment.setNoChecking(true);

--- a/compiler/org/sugarj/driver/transformations/primitive/CompileTransformed.java
+++ b/compiler/org/sugarj/driver/transformations/primitive/CompileTransformed.java
@@ -32,7 +32,6 @@ import org.sugarj.util.Renaming;
  */
 class CompileTransformed extends AbstractPrimitive {
 
-  private boolean generateFiles;
   private Driver driver;
   private Environment environment;
   
@@ -40,7 +39,6 @@ class CompileTransformed extends AbstractPrimitive {
     super("SUGARJ_compile", 0, 2);
     this.driver = driver;
     this.environment = environment;
-    this.generateFiles = environment.doGenerateFiles();
   }
 
   @Override
@@ -64,8 +62,7 @@ class CompileTransformed extends AbstractPrimitive {
         environment.getRenamings().add(0, ren);
 //        generatedModel = driver.currentRename(generatedModel);
         
-        if (generateFiles)
-          driver.getCurrentResult().generateFile(source, ATermCommands.atermToString(generatedModel));
+        driver.getCurrentResult().generateFile(source, ATermCommands.atermToString(generatedModel));
       } catch (IOException e) {
         driver.setErrorMessage(e.getLocalizedMessage());
       }

--- a/compiler/org/sugarj/driver/transformations/primitive/WriteTransformed.java
+++ b/compiler/org/sugarj/driver/transformations/primitive/WriteTransformed.java
@@ -24,13 +24,11 @@ class WriteTransformed extends AbstractPrimitive {
 
   private Driver driver;
   private Environment environment;
-  private boolean generateFiles;
   
   public WriteTransformed(Driver driver, Environment environment) {
     super("SUGARJ_write", 0, 2);
     this.driver = driver;
     this.environment = environment;
-    this.generateFiles = environment.doGenerateFiles();
   }
 
   @Override
@@ -50,8 +48,7 @@ class WriteTransformed extends AbstractPrimitive {
       environment.getRenamings().add(0, ren);
 //      generatedModel = driver.currentRename(generatedModel);
       
-      if (generateFiles)
-        driver.getCurrentResult().generateFile(source, ATermCommands.atermToString(generatedModel));
+      driver.getCurrentResult().generateFile(source, ATermCommands.atermToString(generatedModel));
     } catch (IOException e) {
       driver.setErrorMessage(e.getLocalizedMessage());
     }

--- a/editor/editor/java/org/sugarj/builder/Builder.java
+++ b/editor/editor/java/org/sugarj/builder/Builder.java
@@ -196,9 +196,7 @@ public class Builder extends IncrementalProjectBuilder {
 
             RelativePath depFile = new RelativePath(environment.getGenDir(), FileCommands.dropExtension(input.sourceFile.getRelativePath()) + ".dep");
             Result res = Result.readDependencyFile(depFile);
-            if (res == null 
-                || !res.isUpToDate(input.sourceFile, environment)
-                || res.isGenerationPending())
+            if (res == null || !res.isUpToDate(input.sourceFile, environment))
               res = Driver.run(input.sourceFile, environment, monitor, input.langLibFactory);
             
             IWorkbenchWindow[] workbenchWindows = PlatformUI.getWorkbench().getWorkbenchWindows();

--- a/editor/editor/java/org/sugarj/editor/SugarJParseController.java
+++ b/editor/editor/java/org/sugarj/editor/SugarJParseController.java
@@ -188,7 +188,7 @@ public class SugarJParseController extends SugarJParseControllerGenerated {
       if (reqJavaProject != null) {
         Environment projEnv = makeProjectEnvironment(reqJavaProject);
 //        env.getSourcePath().addAll(projEnv.getSourcePath());
-        env.getIncludePath().add(projEnv.getBin());
+        env.getIncludePath().add(projEnv.getGenDir());
       }
     }
   
@@ -200,6 +200,9 @@ public class SugarJParseController extends SugarJParseControllerGenerated {
   private static void setDefaultEnvironmentOptions(Environment environment) {
     if (environment.getCacheDir() == null)
       environment.setCacheDir(new RelativePath(environment.getRoot(), ".sugarjcache"));
+    
+    if (environment.getGenDir() == null)
+      environment.setGenDir(environment.createCachePath("gen"));
     
     environment.setAtomicImportParsing(true);
     

--- a/language-libraries/base/src/org/sugarj/LanguageLib.java
+++ b/language-libraries/base/src/org/sugarj/LanguageLib.java
@@ -96,8 +96,9 @@ public abstract class LanguageLib implements ILanguageLib, Serializable {
 		return rel + Environment.sep;
 	}
 	
-	
-	public void compile(
+	// Returns true is files were generated or if there were no files to generate
+	// Returns false if generation was skipped due to generateFiles being false
+	public boolean compile(
 	    Path outFile, 
 	    SourceFileContent source, 
 	    Path bin,
@@ -109,6 +110,7 @@ public abstract class LanguageLib implements ILanguageLib, Serializable {
 			boolean generateFiles
 			) throws IOException, ClassNotFoundException {
 	  Set<RelativePath> generatedFiles = new HashSet<RelativePath>(previouslyGeneratedFiles);
+	  boolean allGenerated = true;
 	  
 	  for (Set<RelativePath> files: availableGeneratedFilesForSourceFile.values())
       for (RelativePath file : files)
@@ -140,10 +142,15 @@ public abstract class LanguageLib implements ILanguageLib, Serializable {
       throw new ClassNotFoundException("Unresolved import " + e.getMessage() + " in " + outFile);
     }
     
-    if (!outFiles.isEmpty())
+    if (!outFiles.isEmpty()) {
       this.compile(outFiles, bin, path, generateFiles);
+      allGenerated = generateFiles;
+    }
+    
 		for (Path cl : generatedFiles)
 			generatedFileHashes.put(cl, FileCommands.fileHash(cl));
+		
+		return allGenerated;
 	}
 
 	private void checkRequiredPaths(List<String> requiredPaths, Set<RelativePath> generatedFiles) throws ClassNotFoundException {


### PR DESCRIPTION
Hi Sebastian,

separating out the non-LanguageLib file to a different directiory was straightforward as you thought.  All of the model, .dep, .gen, .str, .sdf files are stored in .sugarjcache/gen but that is easy to change if you would prefer them elsewhere.  The only files that get written to bin are those generated by LanguageLibs, and these files are only written on a build.

The only slight problem was when building after a parse,  The parse doesn't write the LanguageLib generated files but the result says that it is up to date.  During a build the result says the file is up to date so the LanguageLib files are never generated.

I added an extra flag to .dep files to say if a file would have generated LanguageLib files but didn't as it was only a parse.  A file with this flag set would say that it is up to date when parsing but not up to date when building.

Bob
