### PR TITLE
Allow base language to be looked up in registry by name

### DIFF
--- a/language-libraries/base/src/org/sugarj/BaseLanguageRegistry.java
+++ b/language-libraries/base/src/org/sugarj/BaseLanguageRegistry.java
@@ -61,6 +61,17 @@ public class BaseLanguageRegistry {
     return baseLanguages.get(extension);
   }
   
+  public synchronized AbstractBaseLanguage getBaseLanguageByName(String languageName) {
+    if (!extensionsLoaded)
+      loadExtensions();
+    
+    for(AbstractBaseLanguage language : baseLanguages.values()) {
+      if(language.getLanguageName().equals(languageName)) 
+        return language;
+    }
+    return null;
+  }
+  
   public synchronized boolean isRegistered(String extension) {
     if (!extensionsLoaded)
       loadExtensions();


### PR DESCRIPTION
Sugar language testing wants to lookup base languages in the registry by name.  A method has been added to BaseLanguageRegistry to provide this functionality
