### PR TITLE
Expose desugared syntax tree via driver Result for Sugar testing

### DIFF
--- a/compiler/src/org/sugarj/driver/Driver.java
+++ b/compiler/src/org/sugarj/driver/Driver.java
@@ -406,6 +406,7 @@ public class Driver{
       }
         
       driverResult.setSugaredSyntaxTree(makeSugaredSyntaxTree());
+      driverResult.setDesugaredSyntaxTree(makeDesugaredSyntaxTree());
       
       if (currentGrammarTBL != null)
         driverResult.registerParseTable(currentGrammarTBL);

--- a/compiler/src/org/sugarj/driver/Result.java
+++ b/compiler/src/org/sugarj/driver/Result.java
@@ -55,6 +55,7 @@ public class Result {
   private List<String> collectedErrors = new LinkedList<String>();
   private Set<BadTokenException> parseErrors = new HashSet<BadTokenException>();
   private IStrategoTerm sugaredSyntaxTree = null;
+  private IStrategoTerm desugaredSyntaxTree;
   private Path parseTableFile;
   private Path desugaringsFile;
   private RelativePath sourceFile;
@@ -315,6 +316,14 @@ public class Result {
   
   public IStrategoTerm getSugaredSyntaxTree() {
     return sugaredSyntaxTree;
+  }
+  
+  public void setDesugaredSyntaxTree(IStrategoTerm desugaredSyntaxTree) {
+    this.desugaredSyntaxTree = desugaredSyntaxTree;
+  }
+  
+  public IStrategoTerm getDesugaredSyntaxTree() {
+    return desugaredSyntaxTree;
   }
   
   void delegateCompilation(Result delegate, Path compileFile, String source, boolean hasNonBaseDec) {

--- a/editor/editor/java/org/sugarj/editor/SugarJParser.java
+++ b/editor/editor/java/org/sugarj/editor/SugarJParser.java
@@ -241,6 +241,7 @@ public class SugarJParser extends JSGLRI {
       public boolean isUpToDate(int h, Environment env) { return false; }
     };
     r.setSugaredSyntaxTree(term);
+    r.setDesugaredSyntaxTree(term);
     r.registerEditorDesugarings(new AbsolutePath(StdLib.failureTrans.getAbsolutePath()));
     return r;
   }


### PR DESCRIPTION
Sugar testing needs access to the desugared syntax tree so I have modified Driver to store it in Result
