### PR TITLE
Fix NullPointerException in parse timeout recovery

### DIFF
--- a/compiler/src/org/sugarj/driver/declprovider/SourceToplevelDeclarationProvider.java
+++ b/compiler/src/org/sugarj/driver/declprovider/SourceToplevelDeclarationProvider.java
@@ -102,12 +102,12 @@ public class SourceToplevelDeclarationProvider implements ToplevelDeclarationPro
         log.logErr(msg, Log.DETAIL);
       
       if (!treeBuilder.isInitialized()) {
-    	SGLR parser = driver.getParser();
-    	if (parser == null && (e instanceof SGLRException))
-    	  parser = ((SGLRException) e).getParser();
-    	if (parser == null)
-    		return new IncrementalParseResult(ATermCommands.factory.makeString(input), "");
-        treeBuilder.initializeTable(driver.getParser().getParseTable(), 0, 0, 0);
+    	  SGLR parser = driver.getParser();
+    	  if (parser == null && (e instanceof SGLRException))
+    	    parser = ((SGLRException) e).getParser();
+    	  if (parser == null)
+    		  return new IncrementalParseResult(ATermCommands.factory.makeString(input), "");
+        treeBuilder.initializeTable(parser.getParseTable(), 0, 0, 0);
         treeBuilder.initializeInput(input, null);
       }
       else if (treeBuilder.getTokenizer().getStartOffset() > start) {


### PR DESCRIPTION
The current code checks for a null driver.getParser() to get a parser from the SGLRException then tries to use driver.getParser() rather than the new parser variable.

Also the code layout was confusing as the if statements were not correctly idented making the code hard to follow.
